### PR TITLE
Fix mvout from spad indexing accumulator

### DIFF
--- a/gemmini.cc
+++ b/gemmini.cc
@@ -241,10 +241,12 @@ void gemmini_t::mvout(reg_t dram_addr, reg_t sp_addr) {
 
         const bool is_last = j + DIM >= cols;
         const auto n_cmd = is_last ? norm_cmd : non_terminating_norm_cmd(norm_cmd);
-
-        should_write = apply_norm(
-            &gemmini_state.accumulator.at(spad_row).at(0),
-            len, n_cmd);
+	
+	if(accumulator) {
+          should_write = apply_norm(
+              &gemmini_state.accumulator.at(spad_row).at(0),
+              len, n_cmd);
+	}
       }
 
       if (!should_write)


### PR DESCRIPTION
Currently mvout from a scratchpad address > accumulator_rows causes a spike out of bounds error.

The should_write flag update looks into the accumulator without checking if the address is an accumulator address. Added a check before accessing the accumulator memory.